### PR TITLE
test/add CLI tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,39 @@
+import pytest
+from click.testing import CliRunner
+from cli import main
+
+def test_version():
+    runner = CliRunner()
+    result = runner.invoke(main, ['version'])
+    assert result.exit_code == 0
+    assert 'Mapper version' in result.output
+
+def test_generate_default():
+    runner = CliRunner()
+    result = runner.invoke(main, ['generate'])
+    assert result.exit_code == 0
+    assert 'Project structure generated' in result.output
+
+def test_generate_with_custom_output():
+    runner = CliRunner()
+    result = runner.invoke(main, ['generate', '--output', 'custom_map.md'])
+    assert result.exit_code == 0
+    assert 'Project structure generated' in result.output
+
+def test_reset_settings():
+    runner = CliRunner()
+    result = runner.invoke(main, ['reset-settings'])
+    assert result.exit_code == 0
+    assert 'Settings have been reset to default values.' in result.output
+
+def test_generate_with_ignore_hidden():
+    runner = CliRunner()
+    result = runner.invoke(main, ['generate', '--ignore-hidden', 'false'])
+    assert result.exit_code == 0
+    assert 'Project structure generated' in result.output
+
+def test_invalid_subcommand():
+    runner = CliRunner()
+    result = runner.invoke(main, ['invalid'])
+    assert result.exit_code != 0
+    assert 'No such command' in result.output


### PR DESCRIPTION
Added comprehensive tests for the CLI module using Click's CliRunner. Tests cover the `version`, `generate` with default and custom options, `reset-settings`, and handling of invalid subcommands to ensure robust CLI functionality.