### PR TITLE
fix/tests: prevent tests from overwriting user files

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,17 @@
 import pytest
 from click.testing import CliRunner
 from mapper.cli import main
+import os
+import tempfile
+
+@pytest.fixture
+def temp_config_file(monkeypatch):
+    with tempfile.NamedTemporaryFile(delete=False) as tf:
+        config_file = tf.name
+    monkeypatch.setattr('mapper.config.CONFIG_FILE', config_file)
+    yield config_file
+    if os.path.exists(config_file):
+        os.remove(config_file)
 
 def test_version():
     runner = CliRunner()
@@ -8,29 +19,44 @@ def test_version():
     assert result.exit_code == 0
     assert 'Mapper version' in result.output
 
-def test_generate_default():
+def test_generate_default(temp_config_file):
     runner = CliRunner()
-    result = runner.invoke(main, ['generate'], input='')  # Provide empty input if needed
-    assert result.exit_code == 0
-    assert 'Project structure generated' in result.output
+    with runner.isolated_filesystem():
+        result = runner.invoke(main, ['generate'])
+        assert result.exit_code == 0
+        assert 'Project structure generated' in result.output
+        # Ensure 'map.md' is created
+        assert os.path.exists('map.md')
 
-def test_generate_with_custom_output():
+def test_generate_with_custom_output(temp_config_file):
     runner = CliRunner()
-    result = runner.invoke(main, ['generate', '--output', 'custom_map.md'])
-    assert result.exit_code == 0
-    assert 'Project structure generated' in result.output
+    with runner.isolated_filesystem():
+        result = runner.invoke(main, ['generate', '--output', 'custom_map.md'])
+        assert result.exit_code == 0
+        assert 'Project structure generated' in result.output
+        # Ensure 'custom_map.md' is created
+        assert os.path.exists('custom_map.md')
 
-def test_reset_settings():
+def test_reset_settings(temp_config_file):
     runner = CliRunner()
-    result = runner.invoke(main, ['reset-settings'])
-    assert result.exit_code == 0
-    assert 'Settings have been reset to default values.' in result.output
+    with runner.isolated_filesystem():
+        # Create a dummy settings file
+        with open(temp_config_file, 'w') as f:
+            f.write('{}')
+        result = runner.invoke(main, ['reset-settings'])
+        assert result.exit_code == 0
+        assert 'Settings have been reset to default values.' in result.output
+        # Ensure the settings file is removed
+        assert not os.path.exists(temp_config_file)
 
-def test_generate_with_ignore_hidden():
+def test_generate_with_ignore_hidden(temp_config_file):
     runner = CliRunner()
-    result = runner.invoke(main, ['generate', '--ignore-hidden', 'false'])
-    assert result.exit_code == 0
-    assert 'Project structure generated' in result.output
+    with runner.isolated_filesystem():
+        result = runner.invoke(main, ['generate', '--ignore-hidden', 'false'])
+        assert result.exit_code == 0
+        assert 'Project structure generated' in result.output
+        # Ensure 'map.md' is created
+        assert os.path.exists('map.md')
 
 def test_invalid_subcommand():
     runner = CliRunner()


### PR DESCRIPTION
- Updated test_cli.py to use isolated filesystem during tests.
- Monkeypatched CONFIG_FILE to prevent modifying user configuration.
- Ensured that output files created during tests do not affect the user's environment.

This fix addresses the issue where tests were creating 'map.md' and 'custom_map.md' in the user's directory, potentially overwriting existing files.