### PR TITLE
Modify output format to list directories before files during recursion

### DIFF
--- a/mapper/core.py
+++ b/mapper/core.py
@@ -10,18 +10,16 @@ def reset_settings():
 
 def traverse_directory(root, patterns, ignore_hidden=True, max_size=1000000):
     structure = {}
-    file_contents = {}  # New dictionary to store file paths and contents
+    file_contents = {}
     ignore_spec, omit_spec = patterns
     for dirpath, dirnames, filenames in os.walk(root):
         rel_path = os.path.relpath(dirpath, root)
         if rel_path == ".":
             rel_path = ""
-        # Prune dirnames based on ignore patterns and hidden directories
         dirnames[:] = [d for d in dirnames if not (
             (ignore_hidden and d.startswith('.')) or
             ignore_spec.match_file(os.path.join(rel_path, d) + '/')
         )]
-        # Prune filenames based on ignore patterns and hidden files
         filenames = [f for f in filenames if not (
             (ignore_hidden and f.startswith('.')) or
             ignore_spec.match_file(os.path.join(rel_path, f))
@@ -46,28 +44,32 @@ def traverse_directory(root, patterns, ignore_hidden=True, max_size=1000000):
 def generate_markdown(structure, file_contents, settings):
     lines = ['Project Repository Structure:\n']
     arrow = settings.get('arrow', '->')
-    indent_char = settings.get('indent_char', '\t')  # Default is now '\t'
+    indent_char = settings.get('indent_char', '\t')
 
-    def recurse(d, depth=0):
+    file_paths_in_order = []
+
+    def recurse(d, depth=0, path=''):
         # Sort items: directories first, then files
         items = list(d.items())
         items.sort(key=lambda x: (0, x[0]) if isinstance(x[1], dict) else (1, x[0]))
         for key, value in items:
             lines.append(f"{indent_char * depth}{arrow} {key}")
+            new_path = os.path.join(path, key) if path else key
             if isinstance(value, dict):
-                recurse(value, depth + 1)
-            # No else block needed here
+                recurse(value, depth + 1, new_path)
+            else:
+                file_paths_in_order.append(new_path)
 
     recurse(structure)
 
-    # Now add the file contents at the bottom
+    # Add the file contents in the same order as they appeared during recursion
     if file_contents:
         lines.append('\n---\n')
-        for file_path, content in sorted(file_contents.items()):
-            # Replace '/' with '\\' for Windows-style paths
+        for file_path in file_paths_in_order:
+            content = file_contents.get(file_path, '[Content Omitted]')
             display_path = file_path.replace('/', os.sep)
             lines.append(f"{display_path}:\n")
-            lines.append("```\n" + content + "\n```\n")
+            lines.append("```\n{content}\n```\n")
             lines.append('---\n')
 
     return "\n".join(lines)


### PR DESCRIPTION
Ensure that both the project structure and file contents are output with directories first and files last.