### PR TITLE
feat: Exclude Mapper-related files from project map

### DIFF
--- a/mapper/utils.py
+++ b/mapper/utils.py
@@ -1,3 +1,5 @@
+# mapper/utils.py
+
 import os
 from pathspec import PathSpec
 
@@ -7,23 +9,35 @@ def normalize_path(path):
 def load_patterns(ignore_path, omit_path):
     ignore_patterns = []
     omit_patterns = []
+
+    # Mapper-related files to always exclude
+    default_ignore = ['.mapignore', 'map.md', '.mapheader', '.mapfooter', '.mapomit', '.mapconfig']
+    default_omit = ['.mapignore', 'map.md', '.mapheader', '.mapfooter', '.mapomit', '.mapconfig']
+
     if os.path.exists(ignore_path):
         with open(ignore_path, 'r') as f:
-            ignore_patterns = [
+            user_ignore = [
                 normalize_path(line.strip()) 
                 for line in f 
                 if line.strip() and not line.startswith('#')
             ]
+            ignore_patterns.extend(user_ignore)
+
     if os.path.exists(omit_path):
         with open(omit_path, 'r') as f:
-            omit_patterns = [
+            user_omit = [
                 normalize_path(line.strip()) 
                 for line in f 
                 if line.strip() and not line.startswith('#')
             ]
+            omit_patterns.extend(user_omit)
+
+    # Always exclude Mapper-related files
+    ignore_patterns.extend(default_ignore)
+    omit_patterns.extend(default_omit)
+
     ignore_spec = PathSpec.from_lines('gitwildmatch', ignore_patterns)
     omit_spec = PathSpec.from_lines('gitwildmatch', omit_patterns)
-    return ignore_spec, omit_spec
     return ignore_spec, omit_spec
 
 def read_file_content(file_path, max_size=1000000):


### PR DESCRIPTION
- Added default ignore and omit patterns for Mapper's own configuration and output files.
- Updated `mapper/utils.py` to enforce exclusion of `.mapignore`, `map.md`, `.mapheader`, `.mapfooter`, `.mapomit`, and `.mapconfig`.

This ensures that Mapper's internal files are never included in the generated project structure, both in structure and contents.