### PR TITLE
Establish CLI foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -e .
+          pip install click
           pip install pytest
 
       - name: Run tests

--- a/mapper/__main__.py
+++ b/mapper/__main__.py
@@ -1,0 +1,29 @@
+"""
+CLI entry point for the Mapper tool.
+"""
+
+import click
+
+@click.group()
+def main():
+    """
+    Main entry point for the Mapper CLI.
+    """
+    pass
+
+@main.command()
+def help():
+    """
+    Display placeholder help information.
+    """
+    click.echo("Placeholder help content")
+
+@main.command()
+def version():
+    """
+    Display placeholder version information.
+    """
+    click.echo("Placeholder version content")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli_foundation.py
+++ b/tests/test_cli_foundation.py
@@ -1,0 +1,14 @@
+import subprocess
+import sys
+
+def test_cli_help_command():
+    """Test that the 'map help' command returns placeholder help content."""
+    process = subprocess.run([sys.executable, "-m", "mapper", "help"], capture_output=True, text=True)
+    assert process.returncode == 0
+    assert "Placeholder help content" in process.stdout
+
+def test_cli_version_command():
+    """Test that the 'map version' command returns placeholder version content."""
+    process = subprocess.run([sys.executable, "-m", "mapper", "version"], capture_output=True, text=True)
+    assert process.returncode == 0
+    assert "Placeholder version content" in process.stdout

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,2 +1,0 @@
-def test_placeholder():
-    assert True


### PR DESCRIPTION
This pull request implements the initial CLI for the Mapper project, including placeholder subcommands for help and version. It also removes the placeholder test file and configures the continuous integration workflow to install the Click library.

**Modified Files**  
1. **mapper/__main__.py**  
   - Created to provide the base CLI commands: `map help` and `map version`.  
2. **tests/test_cli_foundation.py**  
   - Added to verify that the newly introduced CLI subcommands function correctly.  
3. **tests/test_placeholder.py**  
   - Deleted because it was no longer needed.  
4. **.github/workflows/ci.yml**  
   - Updated to include `pip install click` so the CI environment can run the CLI without errors.