### PR TITLE
Add version command

### DIFF
--- a/mapper/__init__.py
+++ b/mapper/__init__.py
@@ -1,3 +1,5 @@
 """
 Mapper package initialization.
 """
+
+__version__ = "0.1.0"

--- a/mapper/__main__.py
+++ b/mapper/__main__.py
@@ -3,6 +3,7 @@ CLI entry point for the Mapper tool.
 """
 
 import click
+from . import __version__
 
 @click.group()
 def main():
@@ -23,7 +24,7 @@ def version():
     """
     Display placeholder version information.
     """
-    click.echo("Placeholder version content")
+    click.echo(f"Mapper version: {__version__}")
 
 if __name__ == "__main__":
     main()

--- a/tests/test_cli_foundation.py
+++ b/tests/test_cli_foundation.py
@@ -8,7 +8,7 @@ def test_cli_help_command():
     assert "Placeholder help content" in process.stdout
 
 def test_cli_version_command():
-    """Test that the 'map version' command returns placeholder version content."""
+    """Test that the 'map version' command returns the current version content."""
     process = subprocess.run([sys.executable, "-m", "mapper", "version"], capture_output=True, text=True)
     assert process.returncode == 0
-    assert "Placeholder version content" in process.stdout
+    assert "Mapper version: 0.1.0" in process.stdout


### PR DESCRIPTION
This pull request introduces a dedicated version variable in `mapper/__init__.py` and updates the `map version` command to display the Mapper version. It also modifies the associated test to verify the correct version output, ensuring alignment with the newly added version variable.

**Modified Files**  
1. **mapper/__init__.py**  
   - Added `__version__ = "0.1.0"` to serve as the single source of truth for the version.  
2. **mapper/__main__.py**  
   - Updated the `map version` command to retrieve and display the version string from `mapper.__version__`.  
3. **tests/test_cli_foundation.py**  
   - Adjusted the version test to check for the actual version output and validate that the command returns the expected string.