### PR TITLE
Add init command and tests

### DIFF
--- a/mapper/__main__.py
+++ b/mapper/__main__.py
@@ -3,6 +3,8 @@ CLI entry point for the Mapper tool.
 """
 
 import click
+import os
+
 from . import __version__
 
 @click.group()
@@ -25,6 +27,34 @@ def version():
     Display placeholder version information.
     """
     click.echo(f"Mapper version: {__version__}")
+
+@main.command()
+def init():
+    """
+    Create Mapper-related files if they do not already exist.
+    """
+    files_to_create = [
+        ".mapheader",
+        ".mapfooter",
+        ".mapignore",
+        ".mapomit",
+        ".mapinclude",
+        ".mapconfig"
+    ]
+
+    for file_name in files_to_create:
+        if not os.path.exists(file_name):
+            try:
+                with open(file_name, "w", encoding="utf-8") as f:
+                    if file_name == ".mapconfig":
+                        f.write("# Mapper configuration file\n")
+                    else:
+                        f.write("")
+                click.echo(f"Created {file_name}")
+            except OSError as e:
+                click.echo(f"Could not create {file_name}: {str(e)}")
+        else:
+            click.echo(f"Skipped {file_name}, already exists.")
 
 if __name__ == "__main__":
     main()

--- a/tests/test_init_command.py
+++ b/tests/test_init_command.py
@@ -1,0 +1,63 @@
+import os
+import subprocess
+import sys
+
+def test_map_init_creates_files(tmp_path):
+    """
+    Verify that 'map init' creates the required Mapper files
+    if they do not exist.
+    """
+    # Move into a temporary directory
+    original_dir = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        process = subprocess.run(
+            [sys.executable, "-m", "mapper", "init"],
+            capture_output=True,
+            text=True
+        )
+        assert process.returncode == 0
+
+        # Check that each file now exists
+        required_files = [
+            ".mapheader",
+            ".mapfooter",
+            ".mapignore",
+            ".mapomit",
+            ".mapinclude",
+            ".mapconfig"
+        ]
+        for f in required_files:
+            assert os.path.exists(f), f"Expected {f} to be created."
+
+    finally:
+        os.chdir(original_dir)
+
+def test_map_init_skips_existing_files(tmp_path):
+    """
+    Confirm that 'map init' does not overwrite existing files.
+    """
+    original_dir = os.getcwd()
+    os.chdir(tmp_path)
+
+    # Pre-create one of the files
+    existing_file = ".mapignore"
+    with open(existing_file, "w", encoding="utf-8") as f:
+        f.write("Pre-existing content")
+
+    try:
+        process = subprocess.run(
+            [sys.executable, "-m", "mapper", "init"],
+            capture_output=True,
+            text=True
+        )
+        assert process.returncode == 0
+
+        # File content should remain unchanged
+        with open(existing_file, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert content == "Pre-existing content"
+
+    finally:
+        os.chdir(original_dir)


### PR DESCRIPTION
This pull request implements the `map init` subcommand to create required Mapper files if they do not already exist, along with associated unit tests to ensure correct behavior when files are newly created or already present.

**Modified Files**
1. **mapper/__main__.py**  
   - Added the `init` command that writes `.mapheader`, `.mapfooter`, `.mapignore`, `.mapomit`, `.mapinclude`, and `.mapconfig` if they do not exist.  
   - Handled file creation errors and skipped overwriting existing files.

2. **tests/test_init_command.py**  
   - Included tests to verify that the `init` command creates all required files.  
   - Confirmed that existing files remain unmodified.