### PR TITLE
Add config subcommand

### DIFF
--- a/mapper/__main__.py
+++ b/mapper/__main__.py
@@ -50,9 +50,13 @@ def parse_mapconfig(config_path=".mapconfig"):
                     except ValueError:
                         # Invalid integer; ignore or handle as needed
                         pass
-                elif key in ("ignore_hidden", "trim_trailing_whitespaces",
-                             "trim_all_empty_lines", "minimal_output",
-                             "use_absolute_path_title"):
+                elif key in (
+                    "ignore_hidden",
+                    "trim_trailing_whitespaces",
+                    "trim_all_empty_lines",
+                    "minimal_output",
+                    "use_absolute_path_title",
+                ):
                     # Convert string to boolean
                     config_data[key] = value.lower() in ("true", "1", "yes")
                 elif key == "encodings":
@@ -67,6 +71,29 @@ def parse_mapconfig(config_path=".mapconfig"):
         pass
 
     return config_data
+
+def write_mapconfig(config_data, config_path=".mapconfig"):
+    """
+    Write the provided configuration dictionary to .mapconfig,
+    attempting to preserve valid formatting.
+    """
+    lines = ["# Mapper configuration file"]
+    for key, value in config_data.items():
+        if isinstance(value, bool):
+            val_str = "true" if value else "false"
+        elif isinstance(value, int):
+            val_str = str(value)
+        elif isinstance(value, list):
+            val_str = ",".join(value)
+        else:
+            val_str = str(value)
+        lines.append(f"{key}={val_str}")
+
+    try:
+        with open(config_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+    except OSError as e:
+        click.echo(f"Could not write to {config_path}: {str(e)}")
 
 def merge_config_with_defaults(file_config, cli_kwargs):
     """
@@ -187,6 +214,57 @@ def init():
                 click.echo(f"Could not create {file_name}: {str(e)}")
         else:
             click.echo(f"Skipped {file_name}, already exists.")
+
+@main.command()
+@click.option("--set", "pairs", multiple=True,
+              help="Set a configuration value in the format key=value.")
+def config(pairs):
+    """
+    Modify .mapconfig by passing --set key=value pairs.
+    Creates .mapconfig if it does not exist.
+    """
+    config_path = ".mapconfig"
+    current_config = parse_mapconfig(config_path)
+
+    updated_count = 0
+    for pair in pairs:
+        if "=" not in pair:
+            click.echo(f"Skipping invalid parameter: {pair}")
+            continue
+        key, value = pair.split("=", 1)
+        key, value = key.strip(), value.strip()
+
+        # Attempt to parse the value similarly to parse_mapconfig
+        if key in ("max_files", "max_characters_per_file"):
+            try:
+                current_config[key] = int(value)
+                updated_count += 1
+            except ValueError:
+                click.echo(f"Invalid integer for {key}: {value}. Skipped.")
+        elif key in (
+            "ignore_hidden",
+            "trim_trailing_whitespaces",
+            "trim_all_empty_lines",
+            "minimal_output",
+            "use_absolute_path_title",
+        ):
+            bool_val = value.lower() in ("true", "1", "yes")
+            current_config[key] = bool_val
+            updated_count += 1
+        elif key == "encodings":
+            enc_list = [v.strip() for v in value.replace(",", " ").split()]
+            current_config[key] = [enc for enc in enc_list if enc]
+            updated_count += 1
+        else:
+            # Accept any unrecognized key as a string
+            current_config[key] = value
+            updated_count += 1
+
+    if updated_count > 0:
+        write_mapconfig(current_config, config_path)
+        click.echo(f"Updated {updated_count} value(s) in {config_path}")
+    else:
+        click.echo("No valid configuration changes found.")
 
 if __name__ == "__main__":
     main()

--- a/tests/test_config_command.py
+++ b/tests/test_config_command.py
@@ -1,0 +1,149 @@
+import os
+import subprocess
+import sys
+import pytest
+
+def test_map_config_creates_mapconfig(tmp_path):
+    """
+    Verify that 'map config' creates the .mapconfig file if absent,
+    and sets a given key=value pair.
+    """
+    original_dir = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        # Confirm file does not exist initially
+        config_file = ".mapconfig"
+        assert not os.path.exists(config_file), f"{config_file} should not exist yet."
+
+        # Run the command with one --set pair
+        process = subprocess.run(
+            [
+                sys.executable, "-m", "mapper", "config",
+                "--set", "ignore_hidden=true"
+            ],
+            capture_output=True,
+            text=True
+        )
+        assert process.returncode == 0, f"map config exited with code {process.returncode}"
+
+        # Check that .mapconfig was created
+        assert os.path.exists(config_file), f"{config_file} should exist after map config."
+        with open(config_file, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "ignore_hidden=true" in content, "Expected ignore_hidden=true in .mapconfig."
+    finally:
+        os.chdir(original_dir)
+
+def test_map_config_updates_existing_key(tmp_path):
+    """
+    Verify that 'map config' updates an existing key in .mapconfig.
+    """
+    original_dir = os.getcwd()
+    os.chdir(tmp_path)
+
+    config_file = ".mapconfig"
+    initial_content = """# Mapper configuration file
+ignore_hidden=false
+max_files=100
+"""
+    try:
+        # Pre-create .mapconfig
+        with open(config_file, "w", encoding="utf-8") as f:
+            f.write(initial_content)
+
+        # Update ignore_hidden
+        process = subprocess.run(
+            [
+                sys.executable, "-m", "mapper", "config",
+                "--set", "ignore_hidden=true"
+            ],
+            capture_output=True,
+            text=True
+        )
+        assert process.returncode == 0
+
+        # Verify update
+        with open(config_file, "r", encoding="utf-8") as f:
+            final_content = f.read()
+        assert "ignore_hidden=true" in final_content
+        assert "max_files=100" in final_content
+    finally:
+        os.chdir(original_dir)
+
+def test_map_config_invalid_int_value(tmp_path):
+    """
+    Check graceful handling of an invalid integer value for max_files.
+    """
+    original_dir = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        process = subprocess.run(
+            [
+                sys.executable, "-m", "mapper", "config",
+                "--set", "max_files=not_an_int"
+            ],
+            capture_output=True,
+            text=True
+        )
+        assert process.returncode == 0
+        # The command should skip setting this invalid value
+        assert "Invalid integer for max_files" in process.stdout
+        config_file = ".mapconfig"
+        if os.path.exists(config_file):
+            with open(config_file, "r", encoding="utf-8") as f:
+                final_content = f.read()
+            # Should not contain the invalid line
+            assert "max_files=not_an_int" not in final_content
+    finally:
+        os.chdir(original_dir)
+
+def test_map_config_unrecognized_key(tmp_path):
+    """
+    Unrecognized keys should be accepted as string values.
+    """
+    original_dir = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        process = subprocess.run(
+            [
+                sys.executable, "-m", "mapper", "config",
+                "--set", "my_custom_setting=foo"
+            ],
+            capture_output=True,
+            text=True
+        )
+        assert process.returncode == 0
+        config_file = ".mapconfig"
+        assert os.path.exists(config_file)
+
+        with open(config_file, "r", encoding="utf-8") as f:
+            final_content = f.read()
+        assert "my_custom_setting=foo" in final_content
+    finally:
+        os.chdir(original_dir)
+
+def test_map_config_no_valid_pairs(tmp_path):
+    """
+    If no valid --set pairs are provided, .mapconfig should not be written.
+    """
+    original_dir = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        process = subprocess.run(
+            [
+                sys.executable, "-m", "mapper", "config",
+                "--set", "invalidpairs"
+            ],
+            capture_output=True,
+            text=True
+        )
+        assert process.returncode == 0
+        assert "No valid configuration changes found." in process.stdout
+        # .mapconfig should not exist because the pair is invalid
+        assert not os.path.exists(".mapconfig")
+    finally:
+        os.chdir(original_dir)


### PR DESCRIPTION
This pull request introduces a new `map config` subcommand that allows users to create or update the `.mapconfig` file via `--set key=value` parameters. It ensures consistent parsing of integers, booleans, lists, and unrecognized keys.  

**Modified Files**  
1. **mapper/__main__.py**  
   - Added the `map config` subcommand.  
   - Implemented logic to parse and persist configuration changes.  
2. **tests/test_config_command.py**  
   - Created unit tests to verify correct handling of valid and invalid configurations.  