### PR TITLE
Implement ignore/include/omit handling

### DIFF
--- a/mapper/core/filters.py
+++ b/mapper/core/filters.py
@@ -54,16 +54,20 @@ def determine_inclusion_status(
     - is_omitted: True if the path is included but its content should be
       replaced by [omitted].
     """
+
     # If .mapinclude has entries, only those matching its patterns are considered.
     if include_patterns:
         if not is_match(path, include_patterns):
             return False, False
+        # If the path matches .mapinclude, override any .mapignore or .mapomit.
+        return True, False
 
-    # Next, apply .mapignore (if matched, exclude entirely).
+    # If not matched by .mapinclude or .mapinclude is empty,
+    # apply .mapignore (if matched, exclude entirely).
     if is_match(path, ignore_patterns):
         return False, False
 
-    # Finally, apply .mapomit (if matched, content is omitted).
+    # If still included, check .mapomit (if matched, content is omitted).
     if is_match(path, omit_patterns):
         return True, True
 

--- a/mapper/core/filters.py
+++ b/mapper/core/filters.py
@@ -1,0 +1,71 @@
+"""
+Filtering logic for .mapignore, .mapomit, and .mapinclude.
+Uses a .gitignore-like syntax and respects the priority:
+1) .mapinclude > 2) .mapignore > 3) .mapomit.
+"""
+
+import fnmatch
+import os
+
+def parse_pattern_file(file_path):
+    """
+    Parse a file containing patterns (e.g., .mapignore) that follow
+    a .gitignore-like syntax, ignoring empty or commented lines.
+
+    Returns a list of patterns.
+    """
+    patterns = []
+    if not os.path.isfile(file_path):
+        return patterns
+
+    with open(file_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            patterns.append(line)
+    return patterns
+
+def is_match(path, patterns):
+    """
+    Determine whether the given path matches any pattern in the
+    provided list of patterns. This relies on fnmatch.
+    """
+    for pattern in patterns:
+        if fnmatch.fnmatch(path, pattern):
+            return True
+    return False
+
+def determine_inclusion_status(
+    path,
+    include_patterns,
+    ignore_patterns,
+    omit_patterns
+):
+    """
+    Determine whether a file or directory should be included, ignored,
+    or omitted based on patterns from .mapinclude, .mapignore, and .mapomit.
+
+    Returns:
+    (bool should_include, bool is_omitted)
+
+    - should_include: True if the path is included in the final output,
+      False if it is excluded entirely.
+    - is_omitted: True if the path is included but its content should be
+      replaced by [omitted].
+    """
+    # If .mapinclude has entries, only those matching its patterns are considered.
+    if include_patterns:
+        if not is_match(path, include_patterns):
+            return False, False
+
+    # Next, apply .mapignore (if matched, exclude entirely).
+    if is_match(path, ignore_patterns):
+        return False, False
+
+    # Finally, apply .mapomit (if matched, content is omitted).
+    if is_match(path, omit_patterns):
+        return True, True
+
+    # If none of the above patterns apply, include normally.
+    return True, False

--- a/tests/test_ignore_include_omit_handling.py
+++ b/tests/test_ignore_include_omit_handling.py
@@ -1,0 +1,97 @@
+import os
+import pytest
+from mapper.core.filters import (
+    parse_pattern_file,
+    determine_inclusion_status,
+    is_match
+)
+
+@pytest.fixture
+def setup_test_files(tmp_path):
+    """
+    Creates temporary files for .mapignore, .mapomit, and .mapinclude testing.
+    Returns a dictionary of file paths.
+    """
+    files = {
+        "ignore": tmp_path / ".mapignore",
+        "omit": tmp_path / ".mapomit",
+        "include": tmp_path / ".mapinclude",
+    }
+
+    # Provide default content for testing as needed
+    files["ignore"].write_text("# Comment line\n*.log\nsecret*", encoding="utf-8")
+    files["omit"].write_text("# Another comment\n*.md\n", encoding="utf-8")
+    files["include"].write_text("# .mapinclude\n", encoding="utf-8")
+
+    return files
+
+def test_parse_pattern_file(tmp_path, setup_test_files):
+    """
+    Validate that parse_pattern_file correctly reads patterns and ignores comments.
+    """
+    ignore_file = setup_test_files["ignore"]
+    patterns = parse_pattern_file(ignore_file)
+    assert "*.log" in patterns
+    assert "secret*" in patterns
+    assert "# Comment line" not in patterns
+
+def test_is_match_function():
+    """
+    Validate that is_match correctly detects fnmatch patterns.
+    """
+    patterns = ["*.py", "docs/*", "folder[0-9]"]
+    assert is_match("main.py", patterns) is True
+    assert is_match("docs/index.html", patterns) is True
+    assert is_match("folder1", patterns) is True
+    assert is_match("image.jpg", patterns) is False
+
+def test_determine_inclusion_no_include(tmp_path, setup_test_files):
+    """
+    If .mapinclude is empty or contains no valid patterns, then .mapignore and
+    .mapomit alone determine the outcome.
+    """
+    include_patterns = []  # Emulate empty .mapinclude
+    ignore_patterns = ["*.log", "secret*"]
+    omit_patterns = ["*.md"]
+
+    # Excluded by ignore
+    assert determine_inclusion_status("error.log", include_patterns, ignore_patterns, omit_patterns) == (False, False)
+    # Omitted by omit
+    assert determine_inclusion_status("README.md", include_patterns, ignore_patterns, omit_patterns) == (True, True)
+    # Neither ignored nor omitted
+    assert determine_inclusion_status("main.py", include_patterns, ignore_patterns, omit_patterns) == (True, False)
+
+def test_determine_inclusion_with_include(tmp_path, setup_test_files):
+    """
+    If .mapinclude has valid entries, only those patterns are considered first.
+    """
+    include_patterns = ["*.py"]
+    ignore_patterns = ["*.log", "secret*"]
+    omit_patterns = ["*.md"]
+
+    # Must match include to be considered
+    assert determine_inclusion_status("main.py", include_patterns, ignore_patterns, omit_patterns) == (True, False)
+    # Not in include, so excluded regardless of ignore/omit
+    assert determine_inclusion_status("README.md", include_patterns, ignore_patterns, omit_patterns) == (False, False)
+    # Not in include, so excluded
+    assert determine_inclusion_status("error.log", include_patterns, ignore_patterns, omit_patterns) == (False, False)
+
+def test_priority_order(tmp_path, setup_test_files):
+    """
+    Validate that .mapinclude overrides .mapignore, which overrides .mapomit.
+    """
+    # In .mapinclude, so must be included even if also in .mapignore or .mapomit
+    include_patterns = ["secret.txt"]
+    ignore_patterns = ["secret*"]
+    omit_patterns = ["secret.txt"]
+
+    # .mapinclude should override .mapignore and .mapomit
+    should_include, is_omitted = determine_inclusion_status("secret.txt", include_patterns, ignore_patterns, omit_patterns)
+    assert should_include is True
+    # Because .mapinclude is in effect, it is not omitted
+    assert is_omitted is False
+
+    # Not in .mapinclude, so .mapignore applies
+    should_include, is_omitted = determine_inclusion_status("secret_config.yaml", include_patterns, ignore_patterns, omit_patterns)
+    assert should_include is False
+    assert is_omitted is False


### PR DESCRIPTION
This pull request introduces the core functionality for handling `.mapignore`, `.mapomit`, and `.mapinclude` files. It ensures that `.mapinclude` patterns take precedence over `.mapignore` and `.mapomit`, aligning with the specified priority. This update also corrects the failing test related to inclusion order.

**Files Modified**  
1. **mapper/core/filters.py**  
   - Added logic to parse pattern files and determine whether a path should be included, excluded, or omitted, respecting the order of `.mapinclude > .mapignore > .mapomit`.  
   - Updated `determine_inclusion_status` to ensure `.mapinclude` entries override other patterns.

2. **tests/test_ignore_include_omit_handling.py**  
   - Introduced new test cases to confirm correct behavior of `.mapignore`, `.mapomit`, and `.mapinclude` patterns.  
   - Fixed the failing test by validating that `.mapinclude` supersedes `.mapignore` and `.mapomit`.