### PR TITLE
Implement generate command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           pip install --upgrade pip
           pip install -e .
           pip install click
+          pip install pyperclip
           pip install pytest
 
       - name: Run tests

--- a/mapper/cli/commands/generate_command.py
+++ b/mapper/cli/commands/generate_command.py
@@ -1,0 +1,238 @@
+import os
+import sys
+import click
+
+from mapper.core.filters import (
+    parse_pattern_file,
+    determine_inclusion_status
+)
+from mapper.core.utils import bool_or_none
+from mapper.core.defaults import DEFAULT_CONFIG
+import pyperclip
+
+
+@click.command(name="generate")
+@click.option("--output", "output_file", default=".map",
+              help="Specify an alternate output file instead of .map.")
+@click.option("--clipboard", is_flag=True,
+              help="Copy the generated map content to the clipboard.")
+def generate_cmd(output_file, clipboard):
+    """
+    Generate .map for the current directory, respecting .mapinclude,
+    .mapignore, and .mapomit. Stops if symlinks are found or if
+    file limits are exceeded.
+    """
+    ctx = click.get_current_context()
+    config = ctx.obj if ctx.obj else dict(DEFAULT_CONFIG)
+
+    # Gather patterns from .mapinclude, .mapignore, and .mapomit
+    include_patterns = parse_pattern_file(".mapinclude")
+    # If .mapinclude is empty, ignore it
+    if not include_patterns:
+        include_patterns = []
+    ignore_patterns = parse_pattern_file(".mapignore")
+    omit_patterns = parse_pattern_file(".mapomit")
+
+    # Read .mapheader and .mapfooter if present
+    mapheader_content = read_file_safely(".mapheader")
+    mapfooter_content = read_file_safely(".mapfooter")
+
+    # Perform directory traversal
+    try:
+        content_lines = []
+        # If use_absolute_path_title is True, use absolute path
+        if config.get("use_absolute_path_title", False):
+            top_label = os.path.abspath(os.getcwd())
+        else:
+            top_label = os.path.basename(os.getcwd()) or os.getcwd()
+
+        content_lines.append(top_label)
+        content_lines.append("")  # Spacing line
+
+        tree_lines = []
+        file_count_tracker = [0]  # Use a list for mutable integer
+        build_directory_tree(
+            current_path=".",
+            prefix="",
+            lines=tree_lines,
+            config=config,
+            include_patterns=include_patterns,
+            ignore_patterns=ignore_patterns,
+            omit_patterns=omit_patterns,
+            file_count_tracker=file_count_tracker
+        )
+
+        content_lines.extend(tree_lines)
+
+        # Construct final output
+        final_output = []
+        if mapheader_content:
+            final_output.append(mapheader_content.strip() + "\n")
+
+        final_output.append("\n".join(content_lines))
+
+        if mapfooter_content:
+            final_output.append("\n---\n" + mapfooter_content.strip() + "\n")
+
+        rendered_output = "\n".join(final_output)
+
+        # Write to output file unless constraints have already halted
+        # If constraints are violated, an exception is raised in build_directory_tree
+        with open(output_file, "w", encoding="utf-8") as f:
+            f.write(rendered_output + "\n")
+
+        # Copy to clipboard if requested
+        if clipboard:
+            try:
+                pyperclip.copy(rendered_output)
+            except pyperclip.PyperclipException as e:
+                click.echo(f"Clipboard copy failed: {e}", err=True)
+
+    except SymlinkEncounteredError as e:
+        click.echo(str(e), err=True)
+        sys.exit(1)
+    except ConstraintViolatedError as e:
+        click.echo(str(e), err=True)
+        sys.exit(1)
+
+
+def build_directory_tree(
+    current_path,
+    prefix,
+    lines,
+    config,
+    include_patterns,
+    ignore_patterns,
+    omit_patterns,
+    file_count_tracker
+):
+    """
+    Recursively traverse the directory structure, appending lines
+    representing files and directories to 'lines'.
+    Raise errors if symlinks are encountered or if file limits are exceeded.
+    """
+    entries = sorted(os.listdir(current_path))
+    for i, entry in enumerate(entries):
+        if entry in (
+            ".mapheader",
+            ".mapfooter",
+            ".mapignore",
+            ".mapomit",
+            ".mapinclude",
+            ".mapconfig"
+        ):
+            # Exclude mapper-related files
+            continue
+
+        # Hidden file check
+        if config.get("ignore_hidden", True) and entry.startswith("."):
+            continue
+
+        entry_path = os.path.join(current_path, entry)
+        # Check for symlinks
+        if os.path.islink(entry_path):
+            raise SymlinkEncounteredError(f"Symlink found: {entry_path}")
+
+        # Determine whether entry is included, ignored, or omitted
+        relative_entry_path = entry_path.lstrip("./\\")
+        should_include, is_omitted = determine_inclusion_status(
+            relative_entry_path,
+            include_patterns,
+            ignore_patterns,
+            omit_patterns
+        )
+        if not should_include:
+            continue
+
+        connector = "├──" if i < len(entries) - 1 else "└──"
+        new_prefix = prefix + ("│   " if i < len(entries) - 1 else "    ")
+
+        if os.path.isdir(entry_path):
+            lines.append(f"{prefix}{connector} {entry}")
+            build_directory_tree(
+                current_path=entry_path,
+                prefix=new_prefix,
+                lines=lines,
+                config=config,
+                include_patterns=include_patterns,
+                ignore_patterns=ignore_patterns,
+                omit_patterns=omit_patterns,
+                file_count_tracker=file_count_tracker
+            )
+        else:
+            # It's a file
+            lines.append(f"{prefix}{connector} {entry}")
+
+            # Update file count
+            file_count_tracker[0] += 1
+            max_files = config.get("max_files")
+            if max_files is not None and file_count_tracker[0] > max_files:
+                raise ConstraintViolatedError(
+                    f"File limit exceeded: more than {max_files} files found."
+                )
+
+            # If omitted, skip content reading
+            if is_omitted:
+                # The specification only shows [omitted] in .map
+                # For minimal_output, do not add content lines
+                if not config.get("minimal_output", False):
+                    lines.append(f"{prefix}    [omitted]")
+                continue
+
+            # Read file contents if needed
+            if not config.get("minimal_output", False):
+                file_content = read_file_with_encodings(entry_path, config)
+                # Trim trailing whitespaces
+                if config.get("trim_trailing_whitespaces", True):
+                    file_content = "\n".join(line.rstrip() for line in file_content.splitlines())
+                # Remove empty lines entirely if specified
+                if config.get("trim_all_empty_lines", False):
+                    file_content = "\n".join(line for line in file_content.splitlines() if line.strip() != "")
+
+                # Check for max_characters_per_file
+                max_chars = config.get("max_characters_per_file")
+                if max_chars is not None and len(file_content) > max_chars:
+                    raise ConstraintViolatedError(
+                        f"Character limit exceeded in {entry} ({len(file_content)} chars)."
+                    )
+
+                if file_content:
+                    for line in file_content.splitlines():
+                        lines.append(f"{prefix}    {line}")
+
+
+def read_file_safely(path):
+    """
+    Return the contents of the file at 'path', or an empty string
+    if the file does not exist.
+    """
+    if not os.path.isfile(path):
+        return ""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+    except OSError:
+        return ""
+
+
+def read_file_with_encodings(path, config):
+    """
+    Attempt to read a file with the encodings specified in config['encodings'],
+    falling back on defaults if reading fails.
+    """
+    encodings_list = config.get("encodings", DEFAULT_CONFIG["encodings"])
+    for enc in encodings_list:
+        try:
+            with open(path, "r", encoding=enc) as f:
+                return f.read()
+        except (UnicodeDecodeError, OSError):
+            continue
+    return ""
+
+
+class SymlinkEncounteredError(Exception):
+    pass
+
+
+class ConstraintViolatedError(Exception):
+    pass

--- a/mapper/cli/main.py
+++ b/mapper/cli/main.py
@@ -57,3 +57,6 @@ main.add_command(init_cmd)
 
 from .commands.config_command import config_cmd
 main.add_command(config_cmd)
+
+from .commands.generate_command import generate_cmd
+main.add_command(generate_cmd)

--- a/tests/test_generate_command.py
+++ b/tests/test_generate_command.py
@@ -1,0 +1,178 @@
+import os
+import subprocess
+import sys
+import pytest
+
+def test_map_generate_creates_default_map(tmp_path):
+    """
+    Validate that 'map generate' produces a .map file by default,
+    respecting minimal rules. No symlinks or large files here.
+    """
+    original_dir = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        # Create a sample file
+        with open("main.py", "w", encoding="utf-8") as f:
+            f.write("print('Hello World')\n")
+
+        process = subprocess.run(
+            [sys.executable, "-m", "mapper", "generate"],
+            capture_output=True,
+            text=True
+        )
+        assert process.returncode == 0
+        assert os.path.exists(".map")
+
+        with open(".map", "r", encoding="utf-8") as f:
+            map_content = f.read()
+        # Basic checks for content presence
+        assert "main.py" in map_content
+        # Check that mapper-related files do not appear
+        # by default (none were created here except .map)
+    finally:
+        os.chdir(original_dir)
+
+def test_map_generate_respects_output_flag(tmp_path):
+    """
+    Verify that specifying --output writes to the given filename.
+    """
+    original_dir = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        with open("example.txt", "w", encoding="utf-8") as f:
+            f.write("Some content")
+
+        custom_output = "custom_map.txt"
+        process = subprocess.run(
+            [
+                sys.executable, "-m", "mapper", "generate",
+                "--output", custom_output
+            ],
+            capture_output=True,
+            text=True
+        )
+        assert process.returncode == 0
+        assert os.path.exists(custom_output)
+        with open(custom_output, "r", encoding="utf-8") as f:
+            out_content = f.read()
+        assert "example.txt" in out_content
+    finally:
+        os.chdir(original_dir)
+
+@pytest.mark.skipif(
+    not hasattr(sys, "platform") or "win" not in sys.platform.lower(),
+    reason="Clipboard test primarily for Windows; cross-platform library might handle others."
+)
+def test_map_generate_clipboard_option(tmp_path):
+    """
+    Confirm that --clipboard attempts to copy the output to the clipboard.
+    On non-Windows systems, this may behave differently depending on library support.
+    """
+    original_dir = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        with open("data.log", "w", encoding="utf-8") as f:
+            f.write("Log data")
+
+        process = subprocess.run(
+            [
+                sys.executable, "-m", "mapper", "generate",
+                "--clipboard"
+            ],
+            capture_output=True,
+            text=True
+        )
+        # The command should not fail; the presence of 'pyperclip' is assumed
+        # Potentially could fail if clipboard is not accessible, in which case
+        # the code logs an error message but does not crash.
+        assert process.returncode == 0
+        assert os.path.exists(".map")
+    finally:
+        os.chdir(original_dir)
+
+def test_map_generate_symlink_halts(tmp_path):
+    """
+    Check that encountering a symlink causes the process to halt with error.
+    """
+    original_dir = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        with open("file.txt", "w", encoding="utf-8") as f:
+            f.write("Some content")
+
+        # Create a symlink if supported
+        if hasattr(os, "symlink"):
+            os.symlink("file.txt", "link_to_file")
+        else:
+            pytest.skip("Symlinks not supported on this platform.")
+
+        process = subprocess.run(
+            [sys.executable, "-m", "mapper", "generate"],
+            capture_output=True,
+            text=True
+        )
+        assert process.returncode != 0
+        assert "Symlink found" in process.stderr
+        assert not os.path.exists(".map")
+    finally:
+        os.chdir(original_dir)
+
+def test_map_generate_file_limits(tmp_path):
+    """
+    Verify that exceeding max_files triggers a constraint error.
+    """
+    original_dir = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        for i in range(3):
+            with open(f"file_{i}.txt", "w", encoding="utf-8") as f:
+                f.write("content")
+
+        # Pass --max-files=2 to override config
+        process = subprocess.run(
+            [
+                sys.executable, "-m", "mapper",
+                "--max-files", "2",
+                "generate"
+            ],
+            capture_output=True,
+            text=True
+        )
+        assert process.returncode != 0
+        assert "File limit exceeded" in process.stderr
+        assert not os.path.exists(".map")
+    finally:
+        os.chdir(original_dir)
+
+def test_map_generate_character_limits(tmp_path):
+    """
+    Verify that exceeding max_characters_per_file triggers a constraint error.
+    """
+    original_dir = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        # Create a file with 101 characters
+        with open("large_file.txt", "w", encoding="utf-8") as f:
+            f.write("a" * 101)
+
+        # Pass --max-chars-per-file=100
+        process = subprocess.run(
+            [
+                sys.executable, "-m", "mapper",
+                "--max-chars-per-file", "100",
+                "generate"
+            ],
+            capture_output=True,
+            text=True
+        )
+        assert process.returncode != 0
+        assert "Character limit exceeded" in process.stderr
+        assert not os.path.exists(".map")
+    finally:
+        os.chdir(original_dir)


### PR DESCRIPTION
This pull request introduces the `map generate` subcommand to traverse directories and produce the `.map` file, respecting ignore/omit/include rules, detecting symlinks, and enforcing file and character limits. It also provides an option to copy the generated output to the clipboard, adds corresponding tests, and installs the `pyperclip` dependency in the continuous integration pipeline.

**Modified Files**  
1. **mapper/cli/commands/generate_command.py**  
   - Created new command implementing directory traversal and output generation.  
   - Checks for symlinks, file count, and character count violations.  
   - Integrates optional clipboard copying.

2. **mapper/cli/main.py**  
   - Registers the new `generate` command in the CLI group.

3. **tests/test_generate_command.py**  
   - Adds tests verifying correct `.map` output, symlink handling, limit constraints, and clipboard functionality.

4. **.github/workflows/ci.yml**  
   - Installs `pyperclip` dependency to support clipboard operations.