### PR TITLE
Enhance encoding handling and tests

### DIFF
--- a/mapper/cli/commands/generate_command.py
+++ b/mapper/cli/commands/generate_command.py
@@ -77,7 +77,6 @@ def generate_cmd(output_file, clipboard):
         rendered_output = "\n".join(final_output)
 
         # Write to output file unless constraints have already halted
-        # If constraints are violated, an exception is raised in build_directory_tree
         with open(output_file, "w", encoding="utf-8") as f:
             f.write(rendered_output + "\n")
 
@@ -173,8 +172,6 @@ def build_directory_tree(
 
             # If omitted, skip content reading
             if is_omitted:
-                # The specification only shows [omitted] in .map
-                # For minimal_output, do not add content lines
                 if not config.get("minimal_output", False):
                     lines.append(f"{prefix}    [omitted]")
                 continue
@@ -225,7 +222,7 @@ def read_file_with_encodings(path, config):
         try:
             with open(path, "r", encoding=enc) as f:
                 return f.read()
-        except (UnicodeDecodeError, OSError):
+        except (UnicodeDecodeError, OSError, LookupError):
             continue
     return ""
 

--- a/mapper/core/defaults.py
+++ b/mapper/core/defaults.py
@@ -10,5 +10,12 @@ DEFAULT_CONFIG = {
     "trim_all_empty_lines": False,
     "minimal_output": False,
     "use_absolute_path_title": False,
-    "encodings": ["utf-8", "utf-16", "latin-1"]
+    "encodings": [
+        "utf-8",
+        "utf-16",
+        "latin-1",
+        "ascii",
+        "cp1252",
+        "windows-1251"
+    ]
 }

--- a/tests/test_encoding_handling.py
+++ b/tests/test_encoding_handling.py
@@ -1,0 +1,83 @@
+import os
+import sys
+import pytest
+import subprocess
+
+@pytest.mark.parametrize("encoding_used,content", [
+    ("utf-8", "UTF-8 content"),
+    ("utf-16", "UTF-16 content"),
+    ("latin-1", "Latin-1 content"),
+])
+def test_map_generate_with_various_encodings(tmp_path, encoding_used, content):
+    """
+    Validate that 'map generate' can read files encoded in different encodings.
+    """
+    original_dir = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        # Write .mapconfig with specific encodings (include utf-8, utf-16, latin-1)
+        with open(".mapconfig", "w", encoding="utf-8") as f:
+            f.write("# Mapper configuration file\n")
+            f.write("encodings=utf-8,utf-16,latin-1\n")
+
+        file_name = f"example_{encoding_used}.txt"
+        # Create a file in the specified encoding
+        with open(file_name, "w", encoding=encoding_used) as f:
+            f.write(content)
+
+        # Run 'map generate'
+        process = subprocess.run(
+            [sys.executable, "-m", "mapper", "generate"],
+            capture_output=True,
+            text=True
+        )
+        assert process.returncode == 0, f"map generate failed for {encoding_used}"
+        assert os.path.exists(".map"), ".map file should be created"
+
+        # Verify .map contains the file name and its content (unless minimal_output is True)
+        with open(".map", "r", encoding="utf-8") as map_file:
+            map_content = map_file.read()
+            # The file name must appear in the output tree
+            assert file_name in map_content, f"Expected {file_name} in .map"
+            # The file's content should also appear
+            assert content in map_content, f"Expected file content in .map for {encoding_used}"
+
+    finally:
+        os.chdir(original_dir)
+
+
+def test_map_generate_with_unrecognized_encoding_fallback(tmp_path):
+    """
+    Validate that an unrecognized encoding is skipped, falling back to available encodings
+    without causing an error.
+    """
+    original_dir = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        # Write .mapconfig with an invalid encoding first, then valid encodings
+        with open(".mapconfig", "w", encoding="utf-8") as f:
+            f.write("# Mapper configuration file\n")
+            f.write("encodings=invalid-enc,utf-8\n")
+
+        file_name = "example_fallback.txt"
+        content = "Fallback test content"
+        with open(file_name, "w", encoding="utf-8") as f:
+            f.write(content)
+
+        process = subprocess.run(
+            [sys.executable, "-m", "mapper", "generate"],
+            capture_output=True,
+            text=True
+        )
+        assert process.returncode == 0, "map generate should succeed with fallback"
+        assert os.path.exists(".map"), ".map file should be created"
+
+        with open(".map", "r", encoding="utf-8") as map_file:
+            map_content = map_file.read()
+            assert file_name in map_content, "Expected file name in .map"
+            assert content in map_content, "Expected file content in .map after fallback"
+
+    finally:
+        os.chdir(original_dir)

--- a/tests/test_encoding_handling.py
+++ b/tests/test_encoding_handling.py
@@ -7,6 +7,9 @@ import subprocess
     ("utf-8", "UTF-8 content"),
     ("utf-16", "UTF-16 content"),
     ("latin-1", "Latin-1 content"),
+    ("ascii", "ASCII content"),
+    ("cp1252", "CP1252 content"),
+    ("windows-1251", "Windows-1251 content"),
 ])
 def test_map_generate_with_various_encodings(tmp_path, encoding_used, content):
     """
@@ -16,10 +19,10 @@ def test_map_generate_with_various_encodings(tmp_path, encoding_used, content):
     os.chdir(tmp_path)
 
     try:
-        # Write .mapconfig with specific encodings (include utf-8, utf-16, latin-1)
+        # Write .mapconfig with specific encodings (include utf-8, utf-16, latin-1, ascii, cp1252, windows-1251)
         with open(".mapconfig", "w", encoding="utf-8") as f:
             f.write("# Mapper configuration file\n")
-            f.write("encodings=utf-8,utf-16,latin-1\n")
+            f.write("encodings=utf-8,utf-16,latin-1,ascii,cp1252,windows-1251\n")
 
         file_name = f"example_{encoding_used}.txt"
         # Create a file in the specified encoding


### PR DESCRIPTION
This pull request expands the project's encoding handling capabilities and adds comprehensive tests to validate the fallback logic for unknown encodings. It also updates the default list of encodings to cover a wider range of common cases, ensuring robust file reading in multiple environments.

**Modified Files**  
- **mapper/cli/commands/generate_command.py**  
  - Added `LookupError` handling to skip unknown encodings and proceed with fallback options.  
- **mapper/core/defaults.py**  
  - Expanded the `encodings` list to include additional popular character sets (`ascii`, `cp1252`, `windows-1251`).  
- **tests/test_encoding_handling.py**  
  - Newly created file containing test scenarios for multiple encodings, including both recognized and unrecognized sets.  
  - Enhanced parameterization to cover additional encodings and confirm fallback behavior.