### PR TITLE
Add unified encoding detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -e .
+          pip install chardet
           pip install click
           pip install pyperclip
           pip install pytest

--- a/mapper/core/defaults.py
+++ b/mapper/core/defaults.py
@@ -10,12 +10,5 @@ DEFAULT_CONFIG = {
     "trim_all_empty_lines": False,
     "minimal_output": False,
     "use_absolute_path_title": False,
-    "encodings": [
-        "utf-8",
-        "utf-16",
-        "latin-1",
-        "ascii",
-        "cp1252",
-        "windows-1251"
-    ]
+    "force_encoding": None
 }

--- a/mapper/core/traversal.py
+++ b/mapper/core/traversal.py
@@ -8,6 +8,12 @@ class SymlinkEncounteredError(Exception):
 class ConstraintViolatedError(Exception):
     pass
 
+class EncodingDetectionError(Exception):
+    """
+    Raised when automatic encoding detection fails or is inconclusive.
+    """
+    pass
+
 def read_file_safely(path):
     """
     Return the contents of the file at 'path', or an empty string
@@ -21,19 +27,45 @@ def read_file_safely(path):
     except OSError:
         return ""
 
-def read_file_with_encodings(path, config):
+def read_file_with_encoding_detection(path, config):
     """
-    Attempt to read a file with the encodings specified in config['encodings'],
-    falling back on defaults if reading fails.
+    Detect encoding using an external library or apply force_encoding if set.
+    Raise EncodingDetectionError if detection fails.
     """
-    encodings_list = config.get("encodings", DEFAULT_CONFIG["encodings"])
-    for enc in encodings_list:
+    if not os.path.isfile(path):
+        return ""
+
+    # If the user has explicitly forced a particular encoding, use it directly.
+    forced_enc = config.get("force_encoding")
+    if forced_enc:
         try:
-            with open(path, "r", encoding=enc) as f:
+            with open(path, "r", encoding=forced_enc) as f:
                 return f.read()
         except (UnicodeDecodeError, OSError, LookupError):
-            continue
-    return ""
+            raise EncodingDetectionError(
+                f"Failed to decode {path} using forced encoding: {forced_enc}"
+            )
+
+    # Automatic detection if force_encoding is None.
+    import chardet
+    try:
+        with open(path, "rb") as f:
+            raw_data = f.read()
+        detection_result = chardet.detect(raw_data)
+        detected_enc = detection_result.get("encoding")
+        confidence = detection_result.get("confidence", 0)
+
+        if not detected_enc or confidence < 0.5:
+            raise EncodingDetectionError(
+                f"Encoding detection failed or confidence too low for {path}."
+            )
+
+        return raw_data.decode(detected_enc, errors="strict")
+
+    except (UnicodeDecodeError, OSError):
+        raise EncodingDetectionError(
+            f"Failed to decode {path} with detected encoding: {detected_enc}"
+        )
 
 def build_directory_tree(
     current_path,
@@ -114,7 +146,12 @@ def build_directory_tree(
                 continue
 
             if not config.get("minimal_output", False):
-                file_content = read_file_with_encodings(entry_path, config)
+                try:
+                    file_content = read_file_with_encoding_detection(entry_path, config)
+                except EncodingDetectionError as e:
+                    # Abort if detection fails
+                    raise ConstraintViolatedError(str(e))
+
                 if config.get("trim_trailing_whitespaces", True):
                     file_content = "\n".join(
                         line.rstrip() for line in file_content.splitlines()

--- a/tests/test_encoding_handling.py
+++ b/tests/test_encoding_handling.py
@@ -63,18 +63,27 @@ class TestEncodingHandling:
         with open(".mapconfig", "w", encoding="utf-8") as f:
             f.write("# No forced encoding")
 
-        # Write some data that could cause detection confusion or is invalid
+        # Write some deliberately odd data to cause detection failure.
+        # Using a repeated sequence of random bytes that should not match
+        # any standard encoding with high confidence.
         file_name = "invalid_detection.dat"
         with open(file_name, "wb") as f:
-            # Artificially small snippet that might not be reliably detected
-            f.write(b"\xFF\xFE\x00\xFF")
+            f.write(b"\xFE\xED\xFA\xCE" * 10)
 
         process = subprocess.run(
             [sys.executable, "-m", "mapper", "generate"],
             capture_output=True,
             text=True
         )
+        # We expect chardet to fail or return a confidence < 0.5,
+        # thus causing the Mapper process to exit with a non-zero return code.
         assert process.returncode != 0, "map generate should fail on detection error"
-        assert "detection failed" in process.stderr.lower() or "confidence too low" in process.stderr.lower(), \
-            "Expected detection failure message"
+
+        # Accept either "detection failed", "confidence too low", or "Failed to decode".
+        stderr_lower = process.stderr.lower()
+        valid_failure_substrings = ["detection failed", "confidence too low", "failed to decode"]
+        # Confirm at least one of these phrases is present in stderr:
+        assert any(msg in stderr_lower for msg in valid_failure_substrings), \
+            f"Expected detection failure message, got: {process.stderr}"
+
         assert not os.path.exists(".map"), ".map should not be created on failure"

--- a/tests/test_encoding_handling.py
+++ b/tests/test_encoding_handling.py
@@ -5,62 +5,76 @@ import subprocess
 
 @pytest.mark.usefixtures("in_temp_dir")
 class TestEncodingHandling:
-    @pytest.mark.parametrize("encoding_used,content", [
-        ("utf-8", "UTF-8 content"),
-        ("utf-16", "UTF-16 content"),
-        ("latin-1", "Latin-1 content"),
-        ("ascii", "ASCII content"),
-        ("cp1252", "CP1252 content"),
-        ("windows-1251", "Windows-1251 content"),
-    ])
-    def test_map_generate_with_various_encodings(self, in_temp_dir, encoding_used, content):
+    def test_map_generate_forced_encoding(self, in_temp_dir):
         """
-        Validate that 'map generate' can read files encoded in different encodings.
+        Validate that 'map generate' uses a forced encoding if specified.
         """
+        # Create a custom config with force_encoding
         with open(".mapconfig", "w", encoding="utf-8") as f:
-            f.write("# Mapper configuration file\n")
-            f.write("encodings=utf-8,utf-16,latin-1,ascii,cp1252,windows-1251\n")
+            f.write("force_encoding=utf-8\n")
 
-        file_name = f"example_{encoding_used}.txt"
-        with open(file_name, "w", encoding=encoding_used) as f:
-            f.write(content)
+        file_name = "forced_encoding.txt"
+        with open(file_name, "wb") as f:
+            # Write data that is valid UTF-8
+            f.write("Forced encoding content".encode("utf-8"))
 
         process = subprocess.run(
             [sys.executable, "-m", "mapper", "generate"],
             capture_output=True,
             text=True
         )
-        assert process.returncode == 0, f"map generate failed for {encoding_used}"
+        assert process.returncode == 0, "map generate should succeed with forced UTF-8"
         assert os.path.exists(".map"), ".map file should be created"
-
         with open(".map", "r", encoding="utf-8") as map_file:
             map_content = map_file.read()
-            assert file_name in map_content, f"Expected {file_name} in .map"
-            assert content in map_content, f"Expected file content in .map for {encoding_used}"
+            assert file_name in map_content
+            assert "Forced encoding content" in map_content
 
-    def test_map_generate_with_unrecognized_encoding_fallback(self, in_temp_dir):
+    def test_map_generate_automatic_detection_success(self, in_temp_dir):
         """
-        Validate that an unrecognized encoding is skipped,
-        falling back to available encodings without causing an error.
+        Validate that 'map generate' automatically detects encoding with chardet
+        and includes the file content.
         """
+        # No force_encoding in .mapconfig
         with open(".mapconfig", "w", encoding="utf-8") as f:
-            f.write("# Mapper configuration file\n")
-            f.write("encodings=invalid-enc,utf-8\n")
+            f.write("# No forced encoding")
 
-        file_name = "example_fallback.txt"
-        content = "Fallback test content"
-        with open(file_name, "w", encoding="utf-8") as f:
-            f.write(content)
+        file_name = "auto_detection.txt"
+        with open(file_name, "wb") as f:
+            # Write data in UTF-16
+            f.write("Automatic detection content".encode("utf-16"))
 
         process = subprocess.run(
             [sys.executable, "-m", "mapper", "generate"],
             capture_output=True,
             text=True
         )
-        assert process.returncode == 0, "map generate should succeed with fallback"
+        assert process.returncode == 0, "map generate should succeed with detection"
         assert os.path.exists(".map"), ".map file should be created"
-
         with open(".map", "r", encoding="utf-8") as map_file:
             map_content = map_file.read()
-            assert file_name in map_content, "Expected file name in .map"
-            assert content in map_content, "Expected file content in .map after fallback"
+            assert file_name in map_content
+            assert "Automatic detection content" in map_content
+
+    def test_map_generate_automatic_detection_failure(self, in_temp_dir):
+        """
+        Validate that an ambiguous or unreadable file triggers an error.
+        """
+        with open(".mapconfig", "w", encoding="utf-8") as f:
+            f.write("# No forced encoding")
+
+        # Write some data that could cause detection confusion or is invalid
+        file_name = "invalid_detection.dat"
+        with open(file_name, "wb") as f:
+            # Artificially small snippet that might not be reliably detected
+            f.write(b"\xFF\xFE\x00\xFF")
+
+        process = subprocess.run(
+            [sys.executable, "-m", "mapper", "generate"],
+            capture_output=True,
+            text=True
+        )
+        assert process.returncode != 0, "map generate should fail on detection error"
+        assert "detection failed" in process.stderr.lower() or "confidence too low" in process.stderr.lower(), \
+            "Expected detection failure message"
+        assert not os.path.exists(".map"), ".map should not be created on failure"

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -7,7 +7,6 @@ import pytest
 from mapper.core.traversal import (
     build_directory_tree,
     read_file_safely,
-    read_file_with_encodings,
     SymlinkEncounteredError,
     ConstraintViolatedError
 )
@@ -37,22 +36,6 @@ def test_read_file_safely_access_error():
 
     content = read_file_safely(file_name)
     assert isinstance(content, str)
-
-@pytest.mark.usefixtures("in_temp_dir")
-def test_read_file_with_encodings_fallback():
-    """
-    Validate that read_file_with_encodings tries multiple encodings and returns an empty
-    string if none work.
-    """
-    config = dict(DEFAULT_CONFIG)
-    config["encodings"] = ["ascii"]
-    file_name = "unicode_file.txt"
-
-    with open(file_name, "wb") as f:
-        f.write("非ASCII".encode("utf-16"))
-
-    content = read_file_with_encodings(file_name, config)
-    assert content == ""
 
 @pytest.mark.usefixtures("in_temp_dir")
 def test_build_directory_tree_symlink_error():


### PR DESCRIPTION
This pull request consolidates encoding handling into a single, unified detection approach. It introduces a `force_encoding` option, removes legacy multi-encoding logic, and ensures that map generation aborts on detection failure with a clear message. Tests have been updated accordingly, and the CI workflow now installs `chardet` for automatic detection.

**Modified Files**  
1. **mapper/core/defaults.py**  
   - Added `force_encoding` to default configuration.  
   - Removed outdated `encodings` list.  

2. **mapper/core/traversal.py**  
   - Added `EncodingDetectionError` and `read_file_with_encoding_detection`.  
   - Replaced multiple-encoding fallback with a single detection path using `chardet`.  

3. **tests/test_encoding_handling.py**  
   - Revised tests to cover forced encoding, detection success, and detection failure.  
   - Expanded assertions in `test_map_generate_automatic_detection_failure` to match updated error messages.  

4. **tests/test_traversal.py**  
   - Removed references to `read_file_with_encodings`.  
   - Ensured `read_file_safely` usage remains intact.  

5. **.github/workflows/ci.yml**  
   - Installed `chardet` dependency in the CI environment.