### PR TITLE
chore(automation): add CI, lint, and Dependabot scaffolding

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: ['main', 'dev', 'feature/**', 'automations']
+  pull_request:
+    branches: ['main', 'dev']
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: pytest (py${{ matrix.python-version }} • ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install project with dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Hatch & Hatchling for editable install
+          pip install hatch hatchling
+          pip install -e ".[dev]"
+
+      - name: Run test suite
+        run: |
+          pytest --color=yes --cov=mapper --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        if: runner.os == 'Linux' && matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          flags: unittests
+          name: codecov-coverage
+          fail_ci_if_error: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+name: Lint
+
+on:
+  push:
+    branches: ['main', 'dev', 'feature/**', 'automations']
+  pull_request:
+    branches: ['main', 'dev']
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install pre‑commit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+
+      - name: Run pre‑commit hooks
+        run: pre-commit run --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.0
+    hooks:
+      - id: black
+        args: ["--line-length=120"]
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["--profile=black", "--line-length=120"]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.0
+    hooks:
+      - id: ruff
+        args: ["--line-length=120"]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        additional_dependencies: ["types-requests"]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace


### PR DESCRIPTION
This pull request introduces the first wave of repository‑automation infrastructure.

#### ✨  Key additions

| Area                        | File(s)                      | Purpose                                                                                                                     |
| --------------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
| **Continuous Integration**  | `.github/workflows/ci.yml`   | • Runs the full pytest suite on Linux/macOS/Windows across Python 3.9-3.12<br>• Uploads coverage to Codecov (Linux Py 3.12) |
| **Static analysis & style** | `.github/workflows/lint.yml` | Executes the project's pre-commit hooks on each push/PR                                                                     |
| **Pre-commit hooks**        | `.pre-commit-config.yaml`    | Black, isort, Ruff, mypy, and basic whitespace fixers                                                                       |
| **Dependency updates**      | `.github/dependabot.yml`     | Enables weekly Dependabot PRs for `pip` and `github-actions`                                                                |

#### 🛠  How it works

* **CI matrix** assures the codebase stays compatible with our supported Python versions and OSes.
* **Lint workflow** enforces formatting (Black + isort), static analysis (Ruff, mypy), and basic hygiene before code reaches `dev`.
* **Dependabot** will now open weekly PRs keeping both runtime and workflow dependencies fresh and secure.